### PR TITLE
add support for python 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,4 +64,4 @@ target/
 # IntelliJ / Pycharm
 .idea/
 *.iml
-venv
+venv*

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,8 @@ target/
 
 #Ipython Notebook
 .ipynb_checkpoints
+
+# IntelliJ / Pycharm
+.idea/
+*.iml
+venv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.2.1
+* Add Python 3 support
+
 # 0.2.0
 * Add chargeback parser, CBNOTParser
 * Create new class for transaction parser, EPTRNParser

--- a/pyxmex/cbnot_parser.py
+++ b/pyxmex/cbnot_parser.py
@@ -1,7 +1,7 @@
 from yaml import load, dump
 import os
-import utils
-from parser import Parser
+from . import utils
+from .parser import Parser
 
 class CBNOTParser(Parser):
     def __init__(self, config_file=os.path.join(os.path.dirname(os.path.realpath(__file__)), 'config/cbnot.yml')):

--- a/pyxmex/eptrn_parser.py
+++ b/pyxmex/eptrn_parser.py
@@ -1,14 +1,14 @@
 from yaml import load, dump
 import os
-import utils
-from parser import Parser
+from . import utils
+from .parser import Parser
 
 class EPTRNParser(Parser):
     def __init__(self, config_file=os.path.join(os.path.dirname(os.path.realpath(__file__)), 'config/eptrn.yml')):
         super(self.__class__, self).__init__()
 
         self.eptrn_config = load(open(config_file))['DETAIL_RECORD']
-        self.section_types = [v for k, v in self.eptrn_config['TYPE_MAPPING'].iteritems()]
+        self.section_types = [v for k, v in self.eptrn_config['TYPE_MAPPING'].items()]
 
     def process(self, file_name):
         result = {}

--- a/pyxmex/eptrn_parser.py
+++ b/pyxmex/eptrn_parser.py
@@ -1,4 +1,5 @@
 from yaml import load, dump
+from six import iteritems
 import os
 from . import utils
 from .parser import Parser
@@ -8,7 +9,7 @@ class EPTRNParser(Parser):
         super(self.__class__, self).__init__()
 
         self.eptrn_config = load(open(config_file))['DETAIL_RECORD']
-        self.section_types = [v for k, v in self.eptrn_config['TYPE_MAPPING'].items()]
+        self.section_types = [v for k, v in iteritems(self.eptrn_config['TYPE_MAPPING'])]
 
     def process(self, file_name):
         result = {}

--- a/pyxmex/parser.py
+++ b/pyxmex/parser.py
@@ -1,4 +1,4 @@
-import utils
+from . import utils
 from pyxmex.type_caster import TypeCaster
 
 

--- a/pyxmex/type_caster.py
+++ b/pyxmex/type_caster.py
@@ -1,6 +1,6 @@
 import re
 import datetime
-import utils
+from . import utils
 
 
 class TypeCaster():

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def do_setup():
         version=version,
         packages=find_packages(),
         zip_safe=False,
-        install_requires=['pyyaml'],
+        install_requires=['pyyaml', 'six==1.12.0'],
         package_data={'': ['pyxmex/config/*.yml']},
         include_package_data=True,
         author='Rob Froetscher, Joyce Lau',

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '0.2.1'
+version = '0.3.0'
 
 def do_setup():
     setup(

--- a/tests/test_cbnot_parser.py
+++ b/tests/test_cbnot_parser.py
@@ -13,7 +13,7 @@ class TestCBNOTParser(unittest.TestCase):
 
         self.assertEqual(parsed[0]['SE_NUMB'], '1234398429')
         self.assertEqual(parsed[0]['CB_REFERENCE_CODE'], '17512345')
-        self.assertEqual(parsed[0]['DATE_OF_CHARGE'], datetime.datetime(2017, 01, 11))
+        self.assertEqual(parsed[0]['DATE_OF_CHARGE'], datetime.datetime(2017, 1, 11))
         self.assertEqual(parsed[0]['CB_AMOUNT'], -89.95)
 
         self.assertEqual(parsed[1]['CB_AMOUNT'], -33.10)


### PR DESCRIPTION
Some basic changes for supporting relative imports in Python 3, removed leading zero which is not supported in Python 3, added support for dict.iteritems 