### PR TITLE
drop python2 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.3.3
+* Drop Python2 support
+
 # 0.3.2
 * Bump six version to latest
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.3.3
+# 0.4.0
 * Drop Python2 support
 
 # 0.3.2

--- a/pyxmex/eptrn_parser.py
+++ b/pyxmex/eptrn_parser.py
@@ -1,5 +1,4 @@
 from yaml import safe_load
-from six import iteritems
 import os
 from . import utils
 from .parser import Parser
@@ -12,7 +11,7 @@ class EPTRNParser(Parser):
             config = safe_load(f)
 
         self.eptrn_config = config['DETAIL_RECORD']
-        self.section_types = [v for k, v in iteritems(self.eptrn_config['TYPE_MAPPING'])]
+        self.section_types = list(self.eptrn_config['TYPE_MAPPING'].values())
 
         self.record_type_field = config['GENERAL']['RECORD_TYPE_FIELD']
         self.record_types_to_skip = [config['DATA_FILE_HEADER_RECORD']['RECORD_TYPE'],

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '0.3.3'
+version = '0.4.0'
 
 def do_setup():
     setup(

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '0.3.2'
+version = '0.3.3'
 
 def do_setup():
     setup(
@@ -10,7 +10,7 @@ def do_setup():
         version=version,
         packages=find_packages(),
         zip_safe=False,
-        install_requires=['pyyaml', 'six==1.15.0'],
+        install_requires=['pyyaml'],
         package_data={'': ['pyxmex/config/*.yml']},
         include_package_data=True,
         author='Rob Froetscher, Joyce Lau',


### PR DESCRIPTION
drop python2 support and six dependency.

the current six version used is incompatible with Airflow 2.1